### PR TITLE
Fix horizontal movement accuracy

### DIFF
--- a/lib/jquery.tinycircleslider.js
+++ b/lib/jquery.tinycircleslider.js
@@ -353,6 +353,7 @@
 
             if(fireCallback)
             {
+                $overview.css("left", -(self.slideCurrent * slideSize.width));
                 $container.trigger("move", [$slides[self.slideCurrent], self.slideCurrent]);
             }
         }
@@ -424,3 +425,4 @@
         });
     };
 }));
+


### PR DESCRIPTION
The horizontal movement is not accurate. I can't explain it in detail but sometimes the slides doesn't move all the way to their final position. They finish some pixels out of what would be its precise position.

This happens because of the computation you are doing with the angle to get the horizontal position. You lost accuracy. And probably too because of the computation you do in stepmove where it seems you stop the movement before the slide gets to its end position. It is only some pixels out of place but it is not accurate. I can't tell exactly what is happening because I didn't review the maths you are using in detail.

I don't know if this happen in all cases. Maybe with numbers of slides that are divisor of 360 it works correctly or the error is very small but with 25 slides 350 wide I can ensure the problem appears.

With the line of code I have added the issue is resolved. That line of code moves the slide to its precise position at the end of the movement. So if the slide finishes out of place by some pixeles that line corrects the position.

I'm sorry I can't explain it better but you must be more familiarized with the maths you are using to analyze the problem.